### PR TITLE
feat: release v0.0.3 with primitive type support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,55 @@
-## 0.0.1
+# Changelog
 
-* TODO: Describe initial release.
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.0.3] - 2025-08-14
+
+### Added
+- **Primitive type support for listeners**: Added support for `Stream<String>`, `Stream<int>`, `Stream<double>`, `Stream<bool>`, and `Stream<num>` listeners
+- **List of primitives support**: Added support for `Stream<List<String>>`, `Stream<List<int>>`, `Stream<List<double>>`, `Stream<List<bool>>`, and `Stream<List<num>>` listeners
+- **Enhanced emitter type handling**: Emitters now support primitives and raw `Map`/`List` data directly without calling `toJson()`
+- **Standard generated file headers**: All generated files now include coverage ignore and analyzer ignore directives
+- **Type-safe primitive handling**: Primitive listeners include runtime type checking with descriptive error messages
+- **Safe primitive list casting**: Lists of primitives use safe casting with error handling
+
+### Changed
+- **Builder architecture**: Refactored builder to handle primitive types separately from model types
+- **Listener generation logic**: Enhanced to branch between primitive, list-of-primitive, and model listeners
+- **Emitter generation**: Updated to detect primitive types and emit them directly vs. calling `toJson()`
+- **Example interface**: Extended `example/chat_socket.dart` to showcase all supported listener types
+- **Documentation**: Completely rewrote README.md with current features and usage examples
+
+### Technical Details
+- Primitive listeners use `data is Type` checks and emit type errors for mismatches
+- List of primitives use `data.cast<Type>().toList()` for safe conversion
+- Emitters detect primitives via `getDisplayString(withNullability: false)` and type name matching
+- Generated files include standard headers: `// coverage:ignore-file` and comprehensive `// ignore_for_file` directives
+
+## [0.0.2] - 2025-07-31
+
+### Changed
+- **Dependency upgrades**: Updated plugin dependencies to latest compatible versions
+- **Builder optimizations**: Improved code generation efficiency and reduced boilerplate
+
+## [0.0.1] - 2025-07-10
+
+### Added
+- **Initial release**: Basic Socket.IO client code generation
+- **Core annotations**: `@SocketIO()`, `@SocketIOListener()`, and `@SocketIOEmitter()`
+- **Model support**: Generated listeners for custom models with `fromJson()` methods
+- **Stream-based API**: All listeners return Dart streams with automatic cleanup
+- **Basic examples**: Initial example interface and model implementations
+- **Build system integration**: `build.yaml` configuration for code generation
+- **Documentation**: Initial README with setup and usage instructions
+
+### Features
+- Abstract class annotation with `@SocketIO()`
+- Event listener methods returning typed streams
+- Event emitter methods for sending data
+- Automatic Socket.IO event subscription management
+- Stream cleanup and listener removal on cancel

--- a/example/chat_socket.dart
+++ b/example/chat_socket.dart
@@ -3,88 +3,91 @@ import 'dart:async';
 import 'package:socket_io_client/socket_io_client.dart';
 import 'package:socket_io_client_gen_annotations/socket_io_client_gen_annotations.dart';
 
+import 'models/models.dart';
+
 part 'chat_socket.socket.dart';
 
-/// Example message model with fromJson/toJson methods
-class ChatMessage {
-  final int id;
-  final String text;
-  final String sender;
-  final DateTime timestamp;
-
-  ChatMessage({
-    required this.id,
-    required this.text,
-    required this.sender,
-    required this.timestamp,
-  });
-
-  factory ChatMessage.fromJson(Map<String, dynamic> json) {
-    return ChatMessage(
-      id: int.parse(json['id'].toString()),
-      text: json['text'] as String,
-      sender: json['sender'] as String,
-      timestamp: DateTime.parse(json['timestamp'] as String),
-    );
-  }
-
-  Map<String, dynamic> toJson() {
-    return {
-      'id': id,
-      'text': text,
-      'sender': sender,
-      'timestamp': timestamp.toIso8601String(),
-    };
-  }
-}
-
-/// Example user model
-class User {
-  final String id;
-  final String username;
-  final String avatar;
-
-  User({
-    required this.id,
-    required this.username,
-    required this.avatar,
-  });
-
-  factory User.fromJson(Map<String, dynamic> json) {
-    return User(
-      id: json['id'] as String,
-      username: json['username'] as String,
-      avatar: json['avatar'] as String,
-    );
-  }
-
-  Map<String, dynamic> toJson() {
-    return {
-      'id': id,
-      'username': username,
-      'avatar': avatar,
-    };
-  }
-}
-
 /// Abstract class that will be used to generate concrete implementation
-/// This class will be used to generate the concrete implementation
+/// This class showcases all supported stream types
 @SocketIO()
 abstract class ChatSocketSystem {
   factory ChatSocketSystem(Socket socket) = _ChatSocketSystem;
 
-  /// Listen to new messages
+  // ===== STREAM<T> - Single object parsing =====
+  /// Listen to new messages - parses single ChatMessage
   @SocketIOListener('new-message')
   Stream<ChatMessage> listenNewMessages();
 
-  /// Listen to user joined events
+  /// Listen to user joined events - parses single User
   @SocketIOListener('user-joined')
   Stream<User> listenUserJoined();
 
-  /// Listen to user left events
+  /// Listen to user left events - parses single User
   @SocketIOListener('user-left')
   Stream<User> listenUserLeft();
 
+  // ===== STREAM<List<T>> - List of objects parsing =====
+  /// Listen to user list updates - parses List<User>
+  @SocketIOListener('user-list-update')
+  Stream<List<User>> listenUserListUpdate();
+
+  /// Listen to message history - parses List<ChatMessage>
+  @SocketIOListener('message-history')
+  Stream<List<ChatMessage>> listenMessageHistory();
+
+  /// Listen to notification list - parses List<Notification>
+  @SocketIOListener('notification-list')
+  Stream<List<Notification>> listenNotificationList();
+
+  // ===== STREAM<dynamic> - Raw data without transformation =====
+  /// Listen to raw system events - passes through any data type
+  @SocketIOListener('system-event')
+  Stream<dynamic> listenSystemEvents();
+
+  /// Listen to debug information - passes through any data type
+  @SocketIOListener('debug-info')
+  Stream<dynamic> listenDebugInfo();
+
+  // ===== STREAM<void> - Event-only notifications =====
+  /// Listen to typing indicators - only cares about event occurrence
+  @SocketIOListener('user-typing')
+  Stream<void> listenUserTyping();
+
+  /// Listen to connection status changes - only cares about event occurrence
+  @SocketIOListener('connection-status')
+  Stream<void> listenConnectionStatus();
+
+  /// Listen to room join/leave events - only cares about event occurrence
+  @SocketIOListener('room-event')
+  Stream<void> listenRoomEvents();
+
+  // ===== STREAM<PRIMITIVE> - Primitive values pass-through =====
+  /// Listen to server version - parses String primitive
+  @SocketIOListener('server-version')
+  Stream<String> listenServerVersion();
+
+  /// Listen to ping counter - parses int primitive
+  @SocketIOListener('ping-count')
+  Stream<int> listenPingCount();
+
+  /// Listen to CPU load - parses double primitive
+  @SocketIOListener('cpu-load')
+  Stream<double> listenCpuLoad();
+
+  /// Listen to feature flag - parses bool primitive
+  @SocketIOListener('feature-flag')
+  Stream<bool> listenFeatureFlag();
+
+  // ===== STREAM<List<PRIMITIVE>> - Lists of primitive values pass-through =====
+  /// Listen to tags - parses List<String>
+  @SocketIOListener('tags')
+  Stream<List<String>> listenTags();
+
+  /// Listen to scores - parses List<int>
+  @SocketIOListener('scores')
+  Stream<List<int>> listenScores();
+
+  // ===== EMITTERS =====
   /// Emit new message
   @SocketIOEmitter('create-message')
   void emitNewMessage(ChatMessage message);
@@ -92,4 +95,16 @@ abstract class ChatSocketSystem {
   /// Emit user join
   @SocketIOEmitter('join-chat')
   void emitJoinChat(User user);
+
+  /// Emit user leave
+  @SocketIOEmitter('leave-chat')
+  void emitLeaveChat(User user);
+
+  /// Emit typing indicator
+  @SocketIOEmitter('typing')
+  void emitTyping(String userId);
+
+  /// Emit raw data
+  @SocketIOEmitter('raw-data')
+  void emitRawData(dynamic data);
 } 

--- a/example/models/chat_message.dart
+++ b/example/models/chat_message.dart
@@ -1,0 +1,32 @@
+/// Example message model with fromJson/toJson methods
+class ChatMessage {
+  final int id;
+  final String text;
+  final String sender;
+  final DateTime timestamp;
+
+  ChatMessage({
+    required this.id,
+    required this.text,
+    required this.sender,
+    required this.timestamp,
+  });
+
+  factory ChatMessage.fromJson(Map<String, dynamic> json) {
+    return ChatMessage(
+      id: int.parse(json['id'].toString()),
+      text: json['text'] as String,
+      sender: json['sender'] as String,
+      timestamp: DateTime.parse(json['timestamp'] as String),
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'text': text,
+      'sender': sender,
+      'timestamp': timestamp.toIso8601String(),
+    };
+  }
+} 

--- a/example/models/models.dart
+++ b/example/models/models.dart
@@ -1,0 +1,3 @@
+export 'chat_message.dart';
+export 'user.dart';
+export 'notification.dart'; 

--- a/example/models/notification.dart
+++ b/example/models/notification.dart
@@ -1,0 +1,28 @@
+/// Example notification model
+class Notification {
+  final String type;
+  final String message;
+  final DateTime createdAt;
+
+  Notification({
+    required this.type,
+    required this.message,
+    required this.createdAt,
+  });
+
+  factory Notification.fromJson(Map<String, dynamic> json) {
+    return Notification(
+      type: json['type'] as String,
+      message: json['message'] as String,
+      createdAt: DateTime.parse(json['createdAt'] as String),
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'type': type,
+      'message': message,
+      'createdAt': createdAt.toIso8601String(),
+    };
+  }
+} 

--- a/example/models/user.dart
+++ b/example/models/user.dart
@@ -1,0 +1,28 @@
+/// Example user model
+class User {
+  final String id;
+  final String username;
+  final String avatar;
+
+  User({
+    required this.id,
+    required this.username,
+    required this.avatar,
+  });
+
+  factory User.fromJson(Map<String, dynamic> json) {
+    return User(
+      id: json['id'] as String,
+      username: json['username'] as String,
+      avatar: json['avatar'] as String,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'username': username,
+      'avatar': avatar,
+    };
+  }
+} 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: socket_io_client_generator
 description: "Socket io client generator for Flutter - generates files that subscribe to Socket.IO events and redirect them to streams"
-version: 0.0.1
+version: 0.0.3
 publish_to: 'none'
 homepage:
 


### PR DESCRIPTION
This release adds comprehensive support for primitive types in Socket.IO listeners and emitters:

- Added Stream<String|int|double|bool|num> listeners with type checking

- Added Stream<List<primitive>> listeners with safe casting

- Enhanced emitters to handle primitives and raw data directly

- Added standard generated file headers (coverage + analyzer ignores)

- Refactored builder architecture for better type handling

- Updated examples to showcase all supported types

- Completely rewrote documentation with current features

Breaking Changes: None

Migration: No changes required for existing code